### PR TITLE
load gcloud project id in Dockerfile and Jira

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -63,7 +63,7 @@ steps:
 
   # Uses the docker build step to build an image
   name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag', 'gcr.io/$PROJECT_ID/${_IMAGE_NAME}', './philips_hue_integration_example']
+  args: ['build', '--build-arg', 'PROJECT_ID=$PROJECT_ID', '--tag', 'gcr.io/$PROJECT_ID/${_IMAGE_NAME}', './philips_hue_integration_example']
   timeout: 300s # 5 minutes
 
 - id: 'check for required environment variables'

--- a/jira_integration_example/Dockerfile
+++ b/jira_integration_example/Dockerfile
@@ -35,6 +35,9 @@ ENV APP_HOME /app
 WORKDIR $APP_HOME
 COPY . ./
 
+ARG PROJECT_ID
+ENV PROJECT_ID=$PROJECT_ID
+
 # Run the web service on container startup. 
 # Use gunicorn webserver with one worker process and 8 threads.
 # For environments with multiple CPU cores, increase the number of workers

--- a/jira_integration_example/config.py
+++ b/jira_integration_example/config.py
@@ -39,13 +39,14 @@ class ProdJiraConfig(JiraConfig):
         self._jira_username = None
         self._jira_password = None
         self._jira_project = None
+        self._gcloud_project_id = os.environ.get('PROJECT_ID')
 
 
     @property
     def JIRA_URL(self):
         if self._jira_url is None:
             secret = secrets.GoogleSecretManagerSecret(
-                'alertmanager-2020-intern-r', 'jira_url')
+                self._gcloud_project_id, 'jira_url')
             self._jira_url = secret.get_secret_value()
 
         return self._jira_url
@@ -55,7 +56,7 @@ class ProdJiraConfig(JiraConfig):
     def JIRA_USERNAME(self):
         if self._jira_username is None:
             secret = secrets.GoogleSecretManagerSecret(
-                'alertmanager-2020-intern-r', 'jira_username')
+                self._gcloud_project_id, 'jira_username')
             self._jira_username = secret.get_secret_value()
 
         return self._jira_username
@@ -65,7 +66,7 @@ class ProdJiraConfig(JiraConfig):
     def JIRA_PASSWORD(self):
         if self._jira_password is None:
             secret = secrets.GoogleSecretManagerSecret(
-                'alertmanager-2020-intern-r', 'jira_password')
+                self._gcloud_project_id, 'jira_password')
             self._jira_password = secret.get_secret_value()
 
         return self._jira_password
@@ -75,7 +76,7 @@ class ProdJiraConfig(JiraConfig):
     def JIRA_PROJECT(self):
         if self._jira_project is None:
             secret = secrets.GoogleSecretManagerSecret(
-                'alertmanager-2020-intern-r', 'jira_project')
+                self._gcloud_project_id, 'jira_project')
             self._jira_project = secret.get_secret_value()
 
         return self._jira_project

--- a/philips_hue_integration_example/config.py
+++ b/philips_hue_integration_example/config.py
@@ -61,14 +61,14 @@ class ProdPhilipsHueConfig(PhilipsHueConfig):
     def __init__(self):
         self._philips_hue_ip = None
         self._philips_hue_username = None
-        self._project_id = os.environ.get('PROJECT_ID')
+        self._gcloud_project_id = os.environ.get('PROJECT_ID')
 
 
     @property
     def BRIDGE_IP_ADDRESS(self):
         if self._philips_hue_ip is None:
             secret = secrets.GoogleSecretManagerSecret(
-                self._project_id, 'philips_ip')
+                self._gcloud_project_id, 'philips_ip')
             self._philips_hue_ip = secret.get_secret_value()
 
         return self._philips_hue_ip
@@ -78,7 +78,7 @@ class ProdPhilipsHueConfig(PhilipsHueConfig):
     def USERNAME(self):
         if self._philips_hue_username is None:
             secret = secrets.GoogleSecretManagerSecret(
-                self._project_id, 'philips_username')
+                self._gcloud_project_id, 'philips_username')
             self._philips_hue_username = secret.get_secret_value()
 
         return self._philips_hue_username


### PR DESCRIPTION
the gcloud project ID in the Jira configs was hard-coded, so I'm fixing it to load from an environment variable. I also realized I accidentally overwrote the line in cloudbuild.yaml that passes the project id as a argument to the dockerfile (from PR #57), so I added that back.