### PR TITLE
make sure only valid characters are used

### DIFF
--- a/modules/cloud_run_with_pubsub/main.tf
+++ b/modules/cloud_run_with_pubsub/main.tf
@@ -20,6 +20,8 @@ resource "google_project_service" "run" {
 
 resource "random_string" "random" {
   length = 8
+  special = true
+  override_special = "-_"
 }
 
 resource "google_cloud_run_service" "cloud_run_pubsub_service" {

--- a/modules/cloud_run_with_pubsub/main.tf
+++ b/modules/cloud_run_with_pubsub/main.tf
@@ -19,7 +19,7 @@ resource "google_project_service" "run" {
 }
 
 resource "random_string" "random" {
-  length = 8
+  length = 16
   special = true
   override_special = "-_"
 }


### PR DESCRIPTION
GCP labels only allow alphanumeric characters, dashes and underscores so I fixed the resource to conform to the style constraints.