### PR TITLE
generate uuid everytime build happens

### DIFF
--- a/modules/cloud_run_with_pubsub/main.tf
+++ b/modules/cloud_run_with_pubsub/main.tf
@@ -22,6 +22,7 @@ resource "google_cloud_run_service" "cloud_run_pubsub_service" {
   name     = "cloud-run-pubsub-service"
   location = "us-west1"
   project  = var.project
+
   template {
     spec {
       containers {

--- a/modules/cloud_run_with_pubsub/main.tf
+++ b/modules/cloud_run_with_pubsub/main.tf
@@ -18,12 +18,6 @@ resource "google_project_service" "run" {
   project  = var.project
 }
 
-resource "random_string" "random" {
-  length   = 5
-  upper    = false
-  special  = false
-}
-
 resource "google_cloud_run_service" "cloud_run_pubsub_service" {
   name     = "cloud-run-pubsub-service"
   location = "us-west1"
@@ -35,7 +29,7 @@ resource "google_cloud_run_service" "cloud_run_pubsub_service" {
       }
     }
     metadata {
-      name = "cloud-run-pubsub-service-${random_string.random.result}"
+      name = "cloud-run-pubsub-service-${uuid()}"
     }
   }
 


### PR DESCRIPTION
I realized that Terraform's random string provider only generates a random value once and saves it to the Terraform state, so the revisions still aren't being updated. uuid() however generates a new random string every time it's called, so it should be creating new revisions now (I know I submitted a bunch of PRs for this and I'm sorry about that! I tested it out though and I think it actually works this time!)